### PR TITLE
Added formula for inlet flow coefficient from Gülich (2010 p136).

### DIFF
--- a/CCMD.F90
+++ b/CCMD.F90
@@ -207,30 +207,6 @@ WRITE(*,*)
 WRITE(*,*)
 WRITE(*,*)
 WRITE(*,*)
-WRITE(*,*) 'Input Design Flow Coefficient:'
-READ (*,*) FlowCoefficient
-WRITE(*,*)
-WRITE(*,*)
-WRITE(*,*)
-WRITE(*,*)
-WRITE(*,*)
-WRITE(*,*)
-WRITE(*,*)
-WRITE(*,*)
-WRITE(*,*)
-WRITE(*,*)
-WRITE(*,*)
-WRITE(*,*)
-WRITE(*,*)
-WRITE(*,*)
-WRITE(*,*)
-WRITE(*,*)
-WRITE(*,*)
-WRITE(*,*)
-WRITE(*,*)
-WRITE(*,*)
-WRITE(*,*)
-WRITE(*,*)
 WRITE(*,*) 'Please Enter Output File Name (i.e. ConceptOne.txt):'
 READ (*,*) Outfile
 OPEN(UNIT=10,FILE=OutFile,STATUS='NEW')
@@ -544,6 +520,7 @@ END IF
     U2=r2*2*PI*N/60!Blade Speed (m/s)
     PRr=Target_PR+0.2!Rotor Pressure Ratio Guess
     Effr=0.9!Rotor Isentropic Efficiency Guess
+		FlowCoefficient=4*(zMdot*rho01)/(pi*(D1s**2-D1h**2)*U1)!Inlet Flow Coefficient from Gulich (2010 p136)
     DeltaZ = D2*(0.014 + 0.023*D2/D1h + 1.58*FlowCoefficient) !Empirical estimate from Aungier (2000 pg 113)
       
     !ROTOR INLET


### PR DESCRIPTION
During impeller design phase, using this formula it appears to converge on a design with a efficiency, temperature, and pressure more in line with my expectations.

Further isn't the flow rate dependent on u_1 which varies as r1s and r1h are varied? I think it makes more sense to use this formula. 

Formula is:
```
Flow coefficient (inlet): phi_1 = (4 * Q_La) / (f_q * pi * (d_1^2 - d_n^2) * u_1)
flow rate through impeller: Q_La = Q + Q_sp + Q_E + Q_h = Q/ηv
flow rate, volumetric flow: Q
leakage flow rate through seal at impeller inlet: Q_sp
flow rate through axial thrust balancing device: Q_E
flow rate through auxiliaries (mostly zero): Q_h
impeller eyes per impeller: single-entry f_q = 1; double-entry f_q = 2
shroud diameter: d_1
hub diameter: d_n
```

Within the CCMD code, u_1 is based on the inlet meanline radius:
```Fortran

r1m=(0.5*(r1s**2)+0.5*(r1h**2))**0.5!Inlet Meanline Radius (m)
U1=r1m*2*PI*N/60!Blade Speed (m/s)
```

Thank you for this work! I'm still trying to get it to work for me though, but looking in the code everything looks well done.